### PR TITLE
兼容redis 4.0 cluster nodes 数据

### DIFF
--- a/utils/address.cpp
+++ b/utils/address.cpp
@@ -11,7 +11,9 @@ Address Address::from_host_port(std::string const& addr)
     if (host_port.size() != 2) {
         throw std::runtime_error("Invalid address: " + addr);
     }
-    return Address(host_port[0], util::atoi(host_port[1].data()));
+    
+    std::vector<std::string> ports(util::split_str(host_port[1], "@"));
+    return Address(host_port[0], util::atoi(ports[0].data()));
 }
 
 std::set<util::Address> Address::from_hosts_ports(std::string const& addrs)


### PR DESCRIPTION
redis 4.0 获取 cluster info 时，增加了集群端口信息，如下所示，多了 @16380。
修改 Address::from_host_port 使之兼容

b3d08f5138b78985e6267bd8e1473de1cebe4b7a 127.0.0.1:6380@16380 master - 0 1524826274477 2 connected 5461-10922