### PR TITLE
增加proxy层面的auth认证

### DIFF
--- a/core/client.cpp
+++ b/core/client.cpp
@@ -7,6 +7,7 @@
 #include "except/exceptions.hpp"
 #include "utils/logging.hpp"
 #include "syscalls/poll.h"
+#include "globals.hpp"
 
 using namespace cerb;
 
@@ -17,6 +18,7 @@ Client::Client(int fd, Proxy* p)
     : ProxyConnection(fd)
     , _proxy(p)
     , _awaiting_count(0)
+    , _auth(false)
 {
     p->poll_add_ro(this);
 }
@@ -192,4 +194,14 @@ void Client::add_peer(Server* svr)
 void Client::push_command(util::sptr<CommandGroup> g)
 {
     this->_parsed_groups.push_back(std::move(g));
+}
+
+bool Client::is_client_auth()
+{
+    return this->_auth || !cerb_global::need_auth();
+}
+
+void Client::set_client_auth(bool ok)
+{
+    this->_auth = ok;
 }

--- a/core/client.hpp
+++ b/core/client.hpp
@@ -25,6 +25,7 @@ namespace cerb {
         int _awaiting_count;
         Buffer _buffer;
         BufferSet _output_buffer_set;
+        bool _auth;
 
         void _process();
         void _send_buffer_set();
@@ -41,6 +42,8 @@ namespace cerb {
         void add_peer(Server* svr);
         void reactivate(util::sref<Command> cmd);
         void push_command(util::sptr<CommandGroup> g);
+        bool is_client_auth();
+        void set_client_auth(bool ok);
     };
 
 }

--- a/core/globals.cpp
+++ b/core/globals.cpp
@@ -46,3 +46,20 @@ bool cerb_global::cluster_ok()
 {
     return ::cluster_ok;
 }
+
+static std::string auth_pass("");
+
+void cerb_global::set_auth_pass(std::string const& pass)
+{
+	::auth_pass = pass;
+}
+
+bool cerb_global::need_auth() 
+{
+	return ::auth_pass != "";
+}
+
+bool cerb_global::is_auth_ok(std::string const& pass)
+{
+	return ::auth_pass == pass;
+}

--- a/core/globals.hpp
+++ b/core/globals.hpp
@@ -26,6 +26,9 @@ namespace cerb_global {
     void set_cluster_ok(bool ok);
     bool cluster_ok();
 
+    void set_auth_pass(std::string const& pass);
+    bool need_auth();
+    bool is_auth_ok(std::string const& pass);
 }
 
 #endif /* __CERBERUS_GLOBALS_HPP__ */

--- a/main.cpp
+++ b/main.cpp
@@ -117,6 +117,11 @@ namespace {
             cerb_global::set_cluster_req_full_cov(false);
         }
 
+        if (config.get("auth", "") != "") {
+            LOG(INFO) << "Proxy set need auth";
+            cerb_global::set_auth_pass(config.get("auth"));
+        }
+
         int slow_poll_ms = util::atoi(config.get("slow-poll-elapse-ms", "50"));
         if (slow_poll_ms <= 0) {
             LOG(ERROR) << "Invalid slow poll elapse";

--- a/utils/address.cpp
+++ b/utils/address.cpp
@@ -11,7 +11,9 @@ Address Address::from_host_port(std::string const& addr)
     if (host_port.size() != 2) {
         throw std::runtime_error("Invalid address: " + addr);
     }
-    return Address(host_port[0], util::atoi(host_port[1].data()));
+    
+    std::vector<std::string> ports(util::split_str(host_port[1], "@"));
+    return Address(host_port[0], util::atoi(ports[0].data()));
 }
 
 std::set<util::Address> Address::from_hosts_ports(std::string const& addrs)


### PR DESCRIPTION
实现方式是在 proxy 增加 auth 认证，不透传到后端 redis，并且兼容现有非 auth 模式。请 review 下~~

1. Config 增加 auth 字段，兼容认证和非认证模式
2. Client 增加 _auth 字段
3. 增加 AuthCommandParser，用于处理 AUTH 命令，每个 SpecialCommandParser 在 spawn_commands 时先判断是否需要认证，否则返回 NOAUTH_RSP 的 DirectCommandGroup